### PR TITLE
Fix: Use ${node_bin} for the node binary

### DIFF
--- a/LSP-vue.sublime-settings
+++ b/LSP-vue.sublime-settings
@@ -1,5 +1,5 @@
 {
-	"command": ["node", "${server_path}", "--stdio"],
+	"command": ["${node_bin}", "${server_path}", "--stdio"],
 	"languages": [
 		{
 			"languageId": "vue",

--- a/plugin.py
+++ b/plugin.py
@@ -17,10 +17,6 @@ class LspVuePlugin(NpmClientHandler):
     server_binary_path = os.path.join(server_directory, 'node_modules', 'vls', 'bin', 'vls')
 
     @classmethod
-    def install_in_cache(cls) -> bool:
-        return False
-
-    @classmethod
     def on_client_configuration_ready(cls, configuration: dict):
         view = sublime.active_window().active_view()
         if view:


### PR DESCRIPTION
With the latest version of lsp_utils a change was introduced [1] that allows using a locally
managed node runtime instead of the system one. For that to work, the "node" command
needs to use a variable.

[1] https://github.com/sublimelsp/lsp_utils/commit/403345a0c5c15e84802c712044c630a9fb236b9d