### PR TITLE
Adjust the DottedDict update() call after change in LSP

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -22,8 +22,6 @@ class LspVuePlugin(NpmClientHandler):
         if view:
             view_settings = view.settings()
             settings.update({
-                'vetur.format.options': {
-                    'tabSize': view_settings.get('tab_size', 4),
-                    'useTabs': not view_settings.get('translate_tabs_to_spaces', False)
-                }
+                'vetur.format.options.tabSize': view_settings.get('tab_size', 4),
+                'vetur.format.options.useTabs': not view_settings.get('translate_tabs_to_spaces', False),
             })


### PR DESCRIPTION
With https://github.com/sublimelsp/LSP/pull/1865 in place, the updated
format is more correct (even though in this particular case either works
because `vetur.format.options` doesn't contain more options besides
those two).