### PR TITLE
fix expand selection not working in template

### DIFF
--- a/LSP-vue.sublime-settings
+++ b/LSP-vue.sublime-settings
@@ -267,7 +267,7 @@
 	},
 	"selector": "text.html.vue",
 	// Preferred for handling requests in Vue files over LSP-typescript.
-	"priority_selector": "text.html.vue source.js, text.html.vue source.ts",
+	"priority_selector": "text.html.vue, text.html.vue source.js, text.html.vue source.ts",
 	"disabled_capabilities": {
 		"definitionProvider": true,
 		"referencesProvider": true,


### PR DESCRIPTION
Expanding selection didn't work in template tag because `text.html.vue` scope was not in `priority_selector`.

It worked within JS/TS bindings within the template block but not outside those bindings. In both cases we want to use LSP-vue for handling requests.

Before:

https://github.com/user-attachments/assets/f7394f1e-b016-4fb1-a58b-ed9cd5392be9

After:

https://github.com/user-attachments/assets/99f94f5b-4f8e-4821-9c8c-4cc06782c027

